### PR TITLE
Add option to clean startup

### DIFF
--- a/12.10/download/xbmc_upstart_script_2
+++ b/12.10/download/xbmc_upstart_script_2
@@ -14,4 +14,5 @@ respawn
 
 script
   exec su -c "xinit /usr/bin/xbmc --standalone :0" $USER
+  #exec su -c "xinit /usr/bin/xbmc -d --standalone -- -nocursor :0" $USER ##Kill Cursor/Console X and mouse pointer on XBMC start.
 end script


### PR DESCRIPTION
Get rid of cursor on screen everytime when XBMC is started.

Must uncomment 1 option to use `-- -nocursor` which is cursor away.
This may break use of mouse or not, idk as It works perfectly with keyboard and remote.
Mouse is usage is untested..
