### PR TITLE
Fix script versions to match the ones in use currently.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ i386: http://archive.ubuntu.com/ubuntu/dists/quantal/main/installer-i386/current
 
 ```
 cd ~ 
-wget https://github.com/Bram77/xbmc-ubuntu-minimal/raw/master/12.10/prepare_install_2_5.sh
-bash ./prepare_install_2_5.sh
+wget https://github.com/Bram77/xbmc-ubuntu-minimal/raw/master/12.10/prepare_install_2_6_1.sh
+bash ./prepare_install_2_6_1.sh
 ```
+
+[![lgplv3](https://f.cloud.github.com/assets/3521959/153710/2745bbea-7601-11e2-8b61-c8ff3ef97d32.png)](http://www.gnu.org/licenses/lgpl.txt)


### PR DESCRIPTION
Add a beautiful lgplv3 logo which links to the license when clicked. unfortunately doesn't open new tab, as I haven't found the trick yet.
