### PR TITLE
Fix for Intel rogue cards

### DIFF
--- a/12.10/prepare_install_2_6_1.sh
+++ b/12.10/prepare_install_2_6_1.sh
@@ -470,6 +470,8 @@ function installVideoDriver()
         VIDEO_DRIVER="fglrx"
     elif [[ $GFX_CARD == INTEL ]]; then
         VIDEO_DRIVER="i965-va-driver"
+    elif [[ $GFX_CARD == VMWARE ]]; then
+        VIDEO_DRIVER="i965-va-driver"
     else
         cleanUp
         clear


### PR DESCRIPTION
These install a rogue WMWARE driver and Gallium nonsense make the lot unusable apparently.
