### PR TITLE
libcec requires user to be part of dialout group

### DIFF
--- a/12.10/prepare_install_2_6_1.sh
+++ b/12.10/prepare_install_2_6_1.sh
@@ -288,6 +288,7 @@ function addUserToRequiredGroups()
 	sudo adduser $XBMC_USER fuse > /dev/null 2>&1
 	sudo adduser $XBMC_USER cdrom > /dev/null 2>&1
 	sudo adduser $XBMC_USER plugdev > /dev/null 2>&1
+        sudo adduser $XBMC_USER dialout > /dev/null 2>&1
 	showInfo "XBMC user added to required groups"
 }
 


### PR DESCRIPTION
Ideally this part should only be ran if libcec device is detected. I dont have one or know how to add this properly its only a suggestion.

Add basic permissions for common things should be added.
