### PR TITLE
Remove outdated xvba ppa

### DIFF
--- a/12.10/prepare_install_2_6_1.sh
+++ b/12.10/prepare_install_2_6_1.sh
@@ -38,7 +38,7 @@ SYSCTL_CONF_FILE="/etc/sysctl.conf"
 RSYSLOG_FILE="/etc/init/rsyslog.conf"
 POWERMANAGEMENT_DIR="/var/lib/polkit-1/localauthority/50-local.d/"
 DOWNLOAD_URL="https://github.com/Bram77/xbmc-ubuntu-minimal/raw/master/12.10/download/"
-XBMC_PPA="ppa:wsnipex/xbmc-xvba"
+XBMC_PPA="ppa:wsnipex/xbmc-fernetmenta-master"
 HTS_TVHEADEND_PPA="ppa:jabbors/hts-stable"
 OSCAM_PPA="ppa:oscam/ppa"
 


### PR DESCRIPTION
xvba is outdated and deprecated and abandoned development

This ppa still has all improvements xvba had except xvba itself.
